### PR TITLE
Modify task settings to start even on battery

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -113,6 +113,9 @@ namespace MyTrayApp
                 td.Actions.Add(new ExecAction(Application.ExecutablePath, null, null));
                 td.Principal.RunLevel = TaskRunLevel.Highest;
 
+                td.Settings.StopIfGoingOnBatteries = false;
+                td.Settings.DisallowStartIfOnBatteries = false;
+
                 ts.RootFolder.RegisterTaskDefinition(appName, td);
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -116,7 +116,7 @@ namespace MyTrayApp
                 td.Settings.StopIfGoingOnBatteries = false;
                 td.Settings.DisallowStartIfOnBatteries = false;
 
-                td.Settings.UseUnifiedSchedulingEngine = true;  # why not?
+                td.Settings.UseUnifiedSchedulingEngine = true;  // why not?
 
                 ts.RootFolder.RegisterTaskDefinition(appName, td);
             }

--- a/Program.cs
+++ b/Program.cs
@@ -116,6 +116,8 @@ namespace MyTrayApp
                 td.Settings.StopIfGoingOnBatteries = false;
                 td.Settings.DisallowStartIfOnBatteries = false;
 
+                td.Settings.UseUnifiedSchedulingEngine = true;  # why not?
+
                 ts.RootFolder.RegisterTaskDefinition(appName, td);
             }
         }


### PR DESCRIPTION
Sets `Settings.StopIfGoingOnBatteries` and `Settings.DisallowStartIfOnBatteries` to `false`. Both default to true, which doesn't seem sane here to me.
Also, for fun, enable `UseUnifiedSchedulingEngine`.
Should fix #6, but have not tested it.
Perhaps this project should also consider moving to .NET 8?